### PR TITLE
getPackage().getAnnotations() returns empty result on JDK11

### DIFF
--- a/src/main/java/org/codehaus/plexus/classworlds/realm/ClassRealm.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/realm/ClassRealm.java
@@ -272,6 +272,10 @@ public class ClassRealm
         }
     }
 
+    protected Class<?> findClass(String moduleName, String name) throws ClassNotFoundException {
+        return super.findClass(name);
+    }
+
     protected Class<?> findClass( String name )
         throws ClassNotFoundException
     {


### PR DESCRIPTION
I am using a plugin that calls `Package.getAnnotation` that works on JDK8 and returns annotations on `package-info.class`, but on JDK11 it fails and returns nothing. The reason is:
```
"main"
	at java.lang.ClassNotFoundException.<init>(ClassNotFoundException.java:82)
	at org.codehaus.plexus.classworlds.realm.ClassRealm.findClass(ClassRealm.java:282)
	at java.lang.ClassLoader.findClass(ClassLoader.java:751)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:633)
	at java.lang.Package.getPackageInfo(Package.java:420)
	at java.lang.Package.getAnnotation(Package.java:441)
```
Probably the way `Package.getAnnotation` is implemented changed in JDK11 and the assumption that `findClass` is never called is no longer true.

One way to fix that is to override the newly added `findClass(moduleName, className)` method, which I am proposing in this PR.