### PR TITLE
Add Automatic-Module-Name to JAR manifest for JPMS compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
           <instructions>
             <_nouses>true</_nouses>
             <Export-Package>org.codehaus.plexus.classworlds.*</Export-Package>
+            <Automatic-Module-Name>org.codehaus.plexus.classworlds</Automatic-Module-Name>
           </instructions>
         </configuration>
       </plugin>
@@ -119,6 +120,9 @@
             <manifest>
               <mainClass>org.codehaus.plexus.classworlds.launcher.Launcher</mainClass>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>org.codehaus.plexus.classworlds</Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fixes #139 - adds 'org.codehaus.plexus.classworlds' as the automatic module name so modularized downstream projects can consume this library on the module path without a full module descriptor.