### PR TITLE
Fix loadGlob using OR instead of AND for glob matching

### DIFF
--- a/src/main/java/org/codehaus/plexus/classworlds/launcher/ConfigurationParser.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/launcher/ConfigurationParser.java
@@ -334,7 +334,7 @@ public class ConfigurationParser {
 
         final String suffix = localName.substring(starLoc + 1);
 
-        File[] matches = dir.listFiles((dir1, name) -> name.startsWith(prefix) || name.endsWith(suffix));
+        File[] matches = dir.listFiles((dir1, name) -> name.startsWith(prefix) && name.endsWith(suffix));
 
         if (matches != null) {
             for (File match : matches) {

--- a/src/test/java/org/codehaus/plexus/classworlds/launcher/ConfigurationParserTest.java
+++ b/src/test/java/org/codehaus/plexus/classworlds/launcher/ConfigurationParserTest.java
@@ -1,7 +1,16 @@
 package org.codehaus.plexus.classworlds.launcher;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.codehaus.plexus.classworlds.AbstractClassWorldsTestCase;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,5 +88,48 @@ class ConfigurationParserTest extends AbstractClassWorldsTestCase {
         String result = this.configurator.filter("cheese${classworlds.test.prop}toast");
 
         assertEquals("cheesetest prop valuetoast", result);
+    }
+
+    @Test
+    void loadGlobMatchesBothPrefixAndSuffix(@TempDir Path tempDir) throws Exception {
+        Files.createFile(tempDir.resolve("maven-core.jar"));
+        Files.createFile(tempDir.resolve("maven-model.jar"));
+        Files.createFile(tempDir.resolve("sisu-plexus.jar"));
+        Files.createFile(tempDir.resolve("guice.jar"));
+
+        List<File> loaded = new ArrayList<>();
+        ConfigurationHandler handler = new NoopConfigurationHandler() {
+            @Override
+            public void addLoadFile(File file) {
+                loaded.add(file);
+            }
+        };
+        ConfigurationParser parser = new ConfigurationParser(handler, System.getProperties());
+
+        parser.loadGlob(tempDir.resolve("maven-*.jar").toString(), false);
+
+        assertEquals(
+                2,
+                loaded.size(),
+                "glob 'maven-*.jar' should match only files starting with 'maven-' AND ending with '.jar'");
+        List<String> names = loaded.stream().map(File::getName).sorted().collect(Collectors.toList());
+        assertEquals(Arrays.asList("maven-core.jar", "maven-model.jar"), names);
+    }
+
+    private abstract static class NoopConfigurationHandler implements ConfigurationHandler {
+        @Override
+        public void setAppMain(String mainClassName, String mainRealmName) {}
+
+        @Override
+        public void addRealm(String realmName) {}
+
+        @Override
+        public void addImportFrom(String realmName, String importSpec) {}
+
+        @Override
+        public void addLoadFile(File file) {}
+
+        @Override
+        public void addLoadURL(java.net.URL url) {}
     }
 }

--- a/src/test/java/org/codehaus/plexus/classworlds/launcher/ConfigurationParserTest.java
+++ b/src/test/java/org/codehaus/plexus/classworlds/launcher/ConfigurationParserTest.java
@@ -106,7 +106,7 @@ class ConfigurationParserTest extends AbstractClassWorldsTestCase {
         };
         ConfigurationParser parser = new ConfigurationParser(handler, System.getProperties());
 
-        parser.loadGlob(tempDir.resolve("maven-*.jar").toString(), false);
+        parser.loadGlob(new File(tempDir.toFile(), "maven-*.jar").toString(), false);
 
         assertEquals(
                 2,


### PR DESCRIPTION
## Summary

- Fix `loadGlob` in `ConfigurationParser` where `||` (OR) was used instead of `&&` (AND) for matching files against prefix and suffix patterns
- The bug was introduced in 4f4cfe64d1 ("Some automatic code cleanups") where an automated refactoring incorrectly simplified the filter lambda, breaking De Morgan's law
- This caused glob patterns like `maven-*.jar` to match **all** `.jar` files instead of only those starting with `maven-`
- Add regression test for `loadGlob` glob matching

## Impact

On Linux ext4, `File.listFiles()` returns files in non-deterministic (inode hash) order. Combined with this bug, `load maven-*.jar` in Maven's `m2.conf` loads all jars in the lib directory in arbitrary order instead of loading `maven-*.jar` files first. This causes class collisions when multiple jars contain the same FQCN — for example, `PlexusXmlBeanConverter` exists in both `maven-embedder.jar` (Maven's custom version with XmlNode handling) and `org.eclipse.sisu.plexus.jar` (Sisu's version without it). When Sisu's version wins the race, Maven's lifecycle configuration injection fails.

This is currently breaking all CI on the Apache Maven `maven-4.0.x` branch (ubuntu-latest, all JDKs) after a GitHub Actions runner image update changed the filesystem layout.

_Claude Code on behalf of Guillaume Nodet_