### PR TITLE
Update parent POM to 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.codehaus.plexus</groupId>
     <artifactId>plexus</artifactId>
-    <version>25</version>
+    <version>26</version>
   </parent>
 
   <artifactId>plexus-classworlds</artifactId>


### PR DESCRIPTION
Parent 26 stops Spotless formatting `src/site/markdown`. Its flexmark formatter rewrites
the fence that closes a YAML front matter block, so a Doxia page loses its title, author and
date to a build that reports success — which is how the problem went unnoticed.

#149 carries that exclusion locally, with a comment saying it can go once a parent releases it.
Once this lands, that exclusion can be dropped.