### PR TITLE
Allow a caller supplied factory to create the class realm

### DIFF
--- a/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
@@ -99,7 +99,9 @@ public class ClassWorld implements Closeable {
      * does not know about.
      * <p>
      * The factory is invoked before the id is known, so a realm whose id is already taken is closed again before
-     * {@link DuplicateRealmException} is thrown; a failure to close it is attached as a suppressed exception.
+     * {@link DuplicateRealmException} is thrown; a failure to close it is attached as a suppressed exception. A
+     * factory that hands back the realm already registered under that id is the one case where nothing is closed,
+     * since closing it would leave a dead realm in this world.
      *
      * @param factory the factory creating the realm, must not be <code>null</code> and must not return
      *            <code>null</code>
@@ -118,12 +120,15 @@ public class ClassWorld implements Closeable {
             throw new IllegalArgumentException("realm " + id + " belongs to a different class world");
         }
 
-        if (realms.containsKey(id)) {
+        ClassRealm registered = realms.get(id);
+        if (registered != null) {
             DuplicateRealmException duplicate = new DuplicateRealmException(this, id);
-            try {
-                realm.close();
-            } catch (Exception e) {
-                duplicate.addSuppressed(e);
+            if (registered != realm) {
+                try {
+                    realm.close();
+                } catch (Exception e) {
+                    duplicate.addSuppressed(e);
+                }
             }
             throw duplicate;
         }

--- a/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
@@ -91,7 +91,7 @@ public class ClassWorld implements Closeable {
             realm = new FilteredClassRealm(filter, this, id, classLoader);
         }
 
-        return register(realm);
+        return register(id, realm);
     }
 
     /**
@@ -102,6 +102,9 @@ public class ClassWorld implements Closeable {
      * {@link DuplicateRealmException} is thrown; a failure to close it is attached as a suppressed exception. A
      * factory that hands back the realm already registered under that id is the one case where nothing is closed,
      * since closing it would leave a dead realm in this world.
+     *
+     * A realm built against another class world is rejected without being closed, since it may be live and
+     * registered over there. The factory runs while this world's monitor is held.
      *
      * @param factory the factory creating the realm, must not be <code>null</code> and must not return
      *            <code>null</code>
@@ -133,11 +136,11 @@ public class ClassWorld implements Closeable {
             throw duplicate;
         }
 
-        return register(realm);
+        return register(id, realm);
     }
 
-    private ClassRealm register(ClassRealm realm) {
-        realms.put(realm.getId(), realm);
+    private ClassRealm register(String id, ClassRealm realm) {
+        realms.put(id, realm);
 
         for (ClassWorldListener listener : listeners) {
             listener.realmCreated(realm);

--- a/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
@@ -25,8 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
@@ -95,45 +95,40 @@ public class ClassWorld implements Closeable {
     }
 
     /**
-     * Adds a class realm obtained from a caller supplied factory, allowing realm implementations that this class
-     * does not know about.
+     * Adds a class realm built by a caller supplied factory, allowing realm implementations that this class does
+     * not know about.
      * <p>
-     * The factory is invoked before the id is known, so a realm whose id is already taken is closed again before
-     * {@link DuplicateRealmException} is thrown; a failure to close it is attached as a suppressed exception. A
-     * factory that hands back the realm already registered under that id is the one case where nothing is closed,
-     * since closing it would leave a dead realm in this world.
+     * The factory is handed the id and runs only once that id is known to be free, so a rejected call has no side
+     * effect and no realm has to be closed again. It runs while this world's monitor is held.
+     * <p>
+     * This is not an overload of {@link #newRealm(String, ClassLoader)} because a second two argument
+     * <code>newRealm</code> would make the existing <code>newRealm(id, null)</code> calls ambiguous.
      *
-     * A realm built against another class world is rejected without being closed, since it may be live and
-     * registered over there. The factory runs while this world's monitor is held.
-     *
-     * @param factory the factory creating the realm, must not be <code>null</code> and must not return
-     *            <code>null</code>
+     * @param id The identifier for this realm, must not be <code>null</code>.
+     * @param factory the factory building the realm for that id, must not be <code>null</code> and must not
+     *            return <code>null</code>
      * @return the created class realm
-     * @throws DuplicateRealmException in case a realm with the id of the created realm does already exist
-     * @throws IllegalArgumentException if the created realm belongs to a different class world
+     * @throws DuplicateRealmException in case a realm with the given id does already exist
+     * @throws IllegalArgumentException if the created realm belongs to a different class world or carries a
+     *             different id
      * @since 2.13.0
      */
-    public synchronized ClassRealm newRealm(Supplier<ClassRealm> factory) throws DuplicateRealmException {
+    public synchronized ClassRealm createRealm(String id, Function<String, ClassRealm> factory)
+            throws DuplicateRealmException {
+        Objects.requireNonNull(id, "id cannot be null");
         Objects.requireNonNull(factory, "factory cannot be null");
 
-        ClassRealm realm = Objects.requireNonNull(factory.get(), "factory returned null realm");
-        String id = Objects.requireNonNull(realm.getId(), "realm id cannot be null");
+        if (realms.containsKey(id)) {
+            throw new DuplicateRealmException(this, id);
+        }
+
+        ClassRealm realm = Objects.requireNonNull(factory.apply(id), "factory returned null realm");
 
         if (realm.getWorld() != this) {
             throw new IllegalArgumentException("realm " + id + " belongs to a different class world");
         }
-
-        ClassRealm registered = realms.get(id);
-        if (registered != null) {
-            DuplicateRealmException duplicate = new DuplicateRealmException(this, id);
-            if (registered != realm) {
-                try {
-                    realm.close();
-                } catch (Exception e) {
-                    duplicate.addSuppressed(e);
-                }
-            }
-            throw duplicate;
+        if (!id.equals(realm.getId())) {
+            throw new IllegalArgumentException("realm for id " + id + " carries id " + realm.getId());
         }
 
         return register(id, realm);

--- a/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/ClassWorld.java
@@ -24,7 +24,9 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
@@ -88,7 +90,49 @@ public class ClassWorld implements Closeable {
         } else {
             realm = new FilteredClassRealm(filter, this, id, classLoader);
         }
-        realms.put(id, realm);
+
+        return register(realm);
+    }
+
+    /**
+     * Adds a class realm obtained from a caller supplied factory, allowing realm implementations that this class
+     * does not know about.
+     * <p>
+     * The factory is invoked before the id is known, so a realm whose id is already taken is closed again before
+     * {@link DuplicateRealmException} is thrown; a failure to close it is attached as a suppressed exception.
+     *
+     * @param factory the factory creating the realm, must not be <code>null</code> and must not return
+     *            <code>null</code>
+     * @return the created class realm
+     * @throws DuplicateRealmException in case a realm with the id of the created realm does already exist
+     * @throws IllegalArgumentException if the created realm belongs to a different class world
+     * @since 2.13.0
+     */
+    public synchronized ClassRealm newRealm(Supplier<ClassRealm> factory) throws DuplicateRealmException {
+        Objects.requireNonNull(factory, "factory cannot be null");
+
+        ClassRealm realm = Objects.requireNonNull(factory.get(), "factory returned null realm");
+        String id = Objects.requireNonNull(realm.getId(), "realm id cannot be null");
+
+        if (realm.getWorld() != this) {
+            throw new IllegalArgumentException("realm " + id + " belongs to a different class world");
+        }
+
+        if (realms.containsKey(id)) {
+            DuplicateRealmException duplicate = new DuplicateRealmException(this, id);
+            try {
+                realm.close();
+            } catch (Exception e) {
+                duplicate.addSuppressed(e);
+            }
+            throw duplicate;
+        }
+
+        return register(realm);
+    }
+
+    private ClassRealm register(ClassRealm realm) {
+        realms.put(realm.getId(), realm);
 
         for (ClassWorldListener listener : listeners) {
             listener.realmCreated(realm);

--- a/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
+++ b/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
@@ -15,13 +15,13 @@ package org.codehaus.plexus.classworlds;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -182,11 +183,11 @@ class ClassWorldTest extends AbstractClassWorldsTestCase {
     }
 
     @Test
-    void testNewRealmWithSupplier() throws Exception {
+    void testCreateRealmWithFactory() throws Exception {
         TestListener listener = new TestListener();
         world.addListener(listener);
 
-        ClassRealm realm = world.newRealm(() -> new CustomClassRealm(world, "custom"));
+        ClassRealm realm = world.createRealm("custom", id -> new CustomClassRealm(world, id));
 
         assertInstanceOf(CustomClassRealm.class, realm);
         assertSame(realm, world.getRealm("custom"));
@@ -194,62 +195,59 @@ class ClassWorldTest extends AbstractClassWorldsTestCase {
     }
 
     @Test
-    void testNewRealmWithSupplierDuplicate() throws Exception {
-        world.newRealm("custom");
-        CustomClassRealm rejected = new CustomClassRealm(world, "custom");
+    void testCreateRealmWithFactoryDuplicateDoesNotRunTheFactory() throws Exception {
+        ClassRealm registered = world.newRealm("custom");
+        registered.addURL(TestUtil.getTestResourceUrl("a.jar"));
 
-        DuplicateRealmException e = assertThrows(DuplicateRealmException.class, () -> world.newRealm(() -> rejected));
+        AtomicBoolean invoked = new AtomicBoolean();
+        DuplicateRealmException e = assertThrows(
+                DuplicateRealmException.class,
+                () -> world.createRealm("custom", id -> {
+                    invoked.set(true);
+                    return new CustomClassRealm(world, id);
+                }));
 
         assertEquals("custom", e.getId());
         assertSame(world, e.getWorld());
-        assertTrue(rejected.closed, "rejected realm should have been closed");
-    }
-
-    @Test
-    void testNewRealmWithSupplierReturningTheRegisteredRealm() throws Exception {
-        ClassRealm registered = world.newRealm("custom");
-        registered.addURL(TestUtil.getTestResourceUrl("a.jar"));
-        assertNotNull(registered.getResource("a.properties"));
-
-        assertThrows(DuplicateRealmException.class, () -> world.newRealm(() -> world.getClassRealm("custom")));
-
+        assertFalse(invoked.get(), "the factory must not run for an id that is already taken");
         assertSame(registered, world.getRealm("custom"));
         assertNotNull(registered.getResource("a.properties"), "the registered realm must not have been closed");
         assertNotNull(registered.loadClass("a.A"));
     }
 
     @Test
-    void testNewRealmWithSupplierFromOtherWorld() throws Exception {
+    void testCreateRealmWithFactoryFromOtherWorld() throws Exception {
         try (ClassWorld otherWorld = new ClassWorld()) {
             ClassRealm foreign = otherWorld.newRealm("foreign");
 
-            assertThrows(IllegalArgumentException.class, () -> world.newRealm(() -> foreign));
+            assertThrows(IllegalArgumentException.class, () -> world.createRealm("foreign", id -> foreign));
             assertTrue(world.getRealms().isEmpty());
             assertNotNull(otherWorld.getClassRealm("foreign"), "the foreign realm must be left alone");
         }
     }
 
     @Test
-    void testNewRealmWithNullSupplier() {
-        assertThrows(NullPointerException.class, () -> world.newRealm((Supplier<ClassRealm>) null));
+    void testCreateRealmWithFactoryReturningForeignId() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> world.createRealm("custom", id -> new CustomClassRealm(world, "somethingElse")));
+        assertTrue(world.getRealms().isEmpty());
     }
 
     @Test
-    void testNewRealmWithSupplierReturningNull() {
-        assertThrows(NullPointerException.class, () -> world.newRealm(() -> null));
+    void testCreateRealmWithNullFactory() {
+        assertThrows(
+                NullPointerException.class, () -> world.createRealm("custom", (Function<String, ClassRealm>) null));
+    }
+
+    @Test
+    void testCreateRealmWithFactoryReturningNull() {
+        assertThrows(NullPointerException.class, () -> world.createRealm("custom", id -> null));
     }
 
     private static class CustomClassRealm extends ClassRealm {
-        boolean closed;
-
         CustomClassRealm(ClassWorld world, String id) {
             super(world, id, null);
-        }
-
-        @Override
-        public void close() throws IOException {
-            closed = true;
-            super.close();
         }
     }
 

--- a/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
+++ b/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
@@ -206,6 +206,19 @@ class ClassWorldTest extends AbstractClassWorldsTestCase {
     }
 
     @Test
+    void testNewRealmWithSupplierReturningTheRegisteredRealm() throws Exception {
+        ClassRealm registered = world.newRealm("custom");
+        registered.addURL(TestUtil.getTestResourceUrl("a.jar"));
+        assertNotNull(registered.getResource("a.properties"));
+
+        assertThrows(DuplicateRealmException.class, () -> world.newRealm(() -> world.getClassRealm("custom")));
+
+        assertSame(registered, world.getRealm("custom"));
+        assertNotNull(registered.getResource("a.properties"), "the registered realm must not have been closed");
+        assertNotNull(registered.loadClass("a.A"));
+    }
+
+    @Test
     void testNewRealmWithSupplierFromOtherWorld() throws Exception {
         ClassWorld otherWorld = new ClassWorld();
         ClassRealm foreign = otherWorld.newRealm("foreign");

--- a/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
+++ b/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
@@ -15,11 +15,13 @@ package org.codehaus.plexus.classworlds;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -176,6 +179,63 @@ class ClassWorldTest extends AbstractClassWorldsTestCase {
         ClassRealm realm = world.newRealm("unfiltered", null, null);
         assertNotNull(realm);
         assertEquals("unfiltered", realm.getId());
+    }
+
+    @Test
+    void testNewRealmWithSupplier() throws Exception {
+        TestListener listener = new TestListener();
+        world.addListener(listener);
+
+        ClassRealm realm = world.newRealm(() -> new CustomClassRealm(world, "custom"));
+
+        assertInstanceOf(CustomClassRealm.class, realm);
+        assertSame(realm, world.getRealm("custom"));
+        assertEquals(1, listener.realmCreatedCount);
+    }
+
+    @Test
+    void testNewRealmWithSupplierDuplicate() throws Exception {
+        world.newRealm("custom");
+        CustomClassRealm rejected = new CustomClassRealm(world, "custom");
+
+        DuplicateRealmException e = assertThrows(DuplicateRealmException.class, () -> world.newRealm(() -> rejected));
+
+        assertEquals("custom", e.getId());
+        assertSame(world, e.getWorld());
+        assertTrue(rejected.closed, "rejected realm should have been closed");
+    }
+
+    @Test
+    void testNewRealmWithSupplierFromOtherWorld() throws Exception {
+        ClassWorld otherWorld = new ClassWorld();
+        ClassRealm foreign = otherWorld.newRealm("foreign");
+
+        assertThrows(IllegalArgumentException.class, () -> world.newRealm(() -> foreign));
+        assertTrue(world.getRealms().isEmpty());
+    }
+
+    @Test
+    void testNewRealmWithNullSupplier() {
+        assertThrows(NullPointerException.class, () -> world.newRealm((Supplier<ClassRealm>) null));
+    }
+
+    @Test
+    void testNewRealmWithSupplierReturningNull() {
+        assertThrows(NullPointerException.class, () -> world.newRealm(() -> null));
+    }
+
+    private static class CustomClassRealm extends ClassRealm {
+        boolean closed;
+
+        CustomClassRealm(ClassWorld world, String id) {
+            super(world, id, null);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
     }
 
     @Test

--- a/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
+++ b/src/test/java/org/codehaus/plexus/classworlds/ClassWorldTest.java
@@ -220,11 +220,13 @@ class ClassWorldTest extends AbstractClassWorldsTestCase {
 
     @Test
     void testNewRealmWithSupplierFromOtherWorld() throws Exception {
-        ClassWorld otherWorld = new ClassWorld();
-        ClassRealm foreign = otherWorld.newRealm("foreign");
+        try (ClassWorld otherWorld = new ClassWorld()) {
+            ClassRealm foreign = otherWorld.newRealm("foreign");
 
-        assertThrows(IllegalArgumentException.class, () -> world.newRealm(() -> foreign));
-        assertTrue(world.getRealms().isEmpty());
+            assertThrows(IllegalArgumentException.class, () -> world.newRealm(() -> foreign));
+            assertTrue(world.getRealms().isEmpty());
+            assertNotNull(otherWorld.getClassRealm("foreign"), "the foreign realm must be left alone");
+        }
     }
 
     @Test


### PR DESCRIPTION
Extracted from #144. That draft needs `ClassWorld` to register a realm implementation it does not know about, and the review there converged on the transformer realm itself living in Maven rather than here — this is the part that belongs in classworlds.

`createRealm(String id, Function<String, ClassRealm> factory)` checks the id before running the factory, so a rejected call has no side effect: no realm to close again, and no way to close the one already registered under that id. The realm handed back is checked against the requested id, so the registry key and `getId()` cannot disagree, and a realm belonging to another world is rejected without being closed since it may be live over there.

It is not an overload of `newRealm`. A second two argument `newRealm` makes the literal `newRealm(id, null)` ambiguous, and `ClassRealm.createChildRealm` relies on that call, as do downstream callers.

Nothing else from #144 comes along: `ClassRealm` stays concrete, the default realm for `newRealm(id, classLoader, null)` is unchanged, and no new dependencies are added.

`@since 2.13.0` presumes this ships as a minor rather than in 2.12.1; the pom moves at release time.

*This change was created with AI assistance.*
