### PR TITLE
Point the SCM URLs at HTTPS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
   <inceptionYear>2002</inceptionYear>
 
   <scm>
-    <connection>scm:git:git@github.com:codehaus-plexus/plexus-classworlds.git</connection>
-    <developerConnection>scm:git:git@github.com:codehaus-plexus/plexus-classworlds.git</developerConnection>
+    <connection>scm:git:https://github.com/codehaus-plexus/plexus-classworlds.git</connection>
+    <developerConnection>${project.scm.connection}</developerConnection>
     <tag>master</tag>
     <url>https://github.com/codehaus-plexus/plexus-classworlds/tree/${project.scm.tag}/</url>
   </scm>


### PR DESCRIPTION
`connection` is meant to be the anonymous, read-only URL, and both it and `developerConnection` here are
the scp-like SSH form. That makes a release depend on the releaser having an SSH key configured, and gives
anonymous consumers a URL they cannot use.

Every other component in the org uses the HTTPS URL, which works through the git credential helper. Same
change as codehaus-plexus/plexus-sec-dispatcher#142, where the SSH form was not merely inconvenient but
malformed and blocked the release outright.

*This change was created with AI assistance.*